### PR TITLE
Prometheus: add some relabeling for pods from default config

### DIFF
--- a/metrics/prom.yaml
+++ b/metrics/prom.yaml
@@ -83,6 +83,14 @@ data:
             action: replace
             target_label: __scheme__
             regex: (.+)
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
       - job_name: "kubernetes-nodes"
         scheme: https
         tls_config:

--- a/metrics/prom.yaml
+++ b/metrics/prom.yaml
@@ -67,22 +67,22 @@ data:
           - role: pod
         scheme: http
         relabel_configs:
-         - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-           action: keep
-           regex: true
-         - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-           action: replace
-           target_label: __metrics_path__
-           regex: (.+)
-         - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-           action: replace
-           regex: ([^:]+)(?::\d+)?;(\d+)
-           replacement: $1:$2
-           target_label: __address__
-         - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
-           action: replace
-           target_label: __scheme__
-           regex: (.+)
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+            action: replace
+            target_label: __scheme__
+            regex: (.+)
       - job_name: "kubernetes-nodes"
         scheme: https
         tls_config:


### PR DESCRIPTION
https://github.com/prometheus/prometheus/blob/release-2.33/documentation/examples/prometheus-kubernetes.yml has some great examples on relabel configs. while I already had most of them (probably stolen from various blog posts), I was missing the relabels for kubernetes' `role: pod` discovery type