### PR TITLE
traefik: enable experimental http3

### DIFF
--- a/_infrastructure/k3s/traefik/traefik-config.yaml
+++ b/_infrastructure/k3s/traefik/traefik-config.yaml
@@ -10,6 +10,11 @@ spec:
     ports:
       web:
         redirectTo: websecure
+      websecure:
+        http3: {}
+    experimental:
+      http3:
+        enabled: false
     service:
       spec:
         externalTrafficPolicy: Local


### PR DESCRIPTION
the docs were somwhat inconsistent about whether to use `http3: true` or `http3: {}`.
the latter seems more robust to updates